### PR TITLE
Add an install script to set up the hybrid solver

### DIFF
--- a/setup_micom
+++ b/setup_micom
@@ -58,17 +58,17 @@ if __name__ == "__main__":
         run_and_check(
             ["python", "-m", "pip", "install", COBRAPY_URL, MICOM_URL, "Cython", "biom-format"],
             "done",
-            ":snake: Installing MICOM...",
+            ":stew: Installing MICOM...",
             "failed installing MICOM :sob:",
-            ":snake: Done."
+            ":white_check_mark: Done."
         )
 
         run_and_check(
             ["pip", "install", "--no-deps", "highspy", OPTLANG_URL],
             "done",
-            ":snake: Installing the hybrid solver...",
+            ":stew: Installing the hybrid solver...",
             "failed installing the solver :sob:",
-            ":snake: Done."
+            ":white_check_mark: Done."
         )
     else:
         con.log(":snake: Everything already installed and working. Skipped.")

--- a/setup_micom
+++ b/setup_micom
@@ -57,7 +57,7 @@ if __name__ == "__main__":
     if not has_hybrid():
         run_and_check(
             ["pip", "install", "-q", COBRAPY_URL, MICOM_URL, "Cython", "biom-format"],
-            "Building wheel for micom (pyproject.toml) ... done",
+            "",
             ":snake: Installing MICOM...",
             "failed installing MICOM :sob:",
             ":snake: Done."
@@ -65,7 +65,7 @@ if __name__ == "__main__":
 
         run_and_check(
             ["pip", "install", "--no-deps", "-q", "highspy", OPTLANG_URL],
-            "Building wheel for optlang (pyproject.toml) ... done",
+            "",
             ":snake: Installing the hybrid solver...",
             "failed installing the solver :sob:",
             ":snake: Done."

--- a/setup_micom
+++ b/setup_micom
@@ -16,7 +16,7 @@ from rich.console import Console  # noqa
 con = Console()
 
 COBRAPY_URL = "git+https://github.com/cdiener/cobrapy@feature/hybrid_solver"
-MICOM_URL = "git+https://github.com/cdiener/cobrapy@feature/hybrid_solver"
+MICOM_URL = "git+https://github.com/micom-dev/micom@feature/hybrid_solver"
 OPTLANG_URL = "git+https://github.com/cdiener/optlang@feature/hybrid_solver"
 
 
@@ -24,7 +24,7 @@ def has_hybrid():
     try:
         import micom as mm
         from cobra.util.solver import interface_to_str
-        com = mm.Community(mm.data.test_taxxonomy(), solver="hybrid")
+        com = mm.Community(mm.data.test_taxonomy(), solver="hybrid")
         assert "hybrid" in interface_to_str(com.solver.problem)
     except Exception:
         return False
@@ -56,16 +56,16 @@ def run_and_check(args, check, message, failure, success, console=con):
 if __name__ == "__main__":
     if not has_hybrid():
         run_and_check(
-            ["pip", "install", "-q", COBRAPY_URL, MICOM_URL, "Cython", "biom-format"],
-            "",
+            ["python", "-m", "pip", "install", COBRAPY_URL, MICOM_URL, "Cython", "biom-format"],
+            "done",
             ":snake: Installing MICOM...",
             "failed installing MICOM :sob:",
             ":snake: Done."
         )
 
         run_and_check(
-            ["pip", "install", "--no-deps", "-q", "highspy", OPTLANG_URL],
-            "",
+            ["pip", "install", "--no-deps", "highspy", OPTLANG_URL],
+            "done",
             ":snake: Installing the hybrid solver...",
             "failed installing the solver :sob:",
             ":snake: Done."

--- a/setup_micom
+++ b/setup_micom
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+
+"""Set up MICOM on Google colab.
+
+Do not use this on o local machine, especially not as an admin!
+"""
+
+import os
+import sys
+import shutil
+from subprocess import Popen, PIPE
+
+r = Popen(["pip", "install", "rich"])
+r.wait()
+from rich.console import Console  # noqa
+con = Console()
+
+COBRAPY_URL = "git+https://github.com/cdiener/cobrapy@feature/hybrid_solver"
+MICOM_URL = "git+https://github.com/cdiener/cobrapy@feature/hybrid_solver"
+OPTLANG_URL = "git+https://github.com/cdiener/optlang@feature/hybrid_solver"
+
+
+def has_hybrid():
+    try:
+        import micom as mm
+        from cobra.util.solver import interface_to_str
+        com = mm.Community(mm.data.test_taxxonomy(), solver="hybrid")
+        assert "hybrid" in interface_to_str(com.solver.problem)
+    except Exception:
+        return False
+    return True
+
+
+def cleanup():
+    """Remove downloaded files."""
+    if os.path.exists("/content/sample_data"):
+        shutil.rmtree("/content/sample_data")
+    con.log(":broom: Cleaned up unneeded files.")
+
+
+def run_and_check(args, check, message, failure, success, console=con):
+    """Run a command and check that it worked."""
+    console.log(message)
+    r = Popen(args, env=os.environ, stdout=PIPE, stderr=PIPE,
+              universal_newlines=True)
+    o, e = r.communicate()
+    out = o + e
+    if r.returncode == 0 and check in out:
+        console.log("[blue]%s[/blue]" % success)
+    else:
+        console.log("[red]%s[/red]" % failure, out)
+        cleanup()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    if not has_hybrid():
+        run_and_check(
+            ["pip", "install", "-q", COBRAPY_URL, MICOM_URL, "Cython", "biom-format"],
+            "Building wheel for micom (pyproject.toml) ... done",
+            ":snake: Installing MICOM...",
+            "failed installing MICOM :sob:",
+            ":snake: Done."
+        )
+
+        run_and_check(
+            ["pip", "install", "--no-deps", "-q", "highspy", OPTLANG_URL],
+            "Building wheel for optlang (pyproject.toml) ... done",
+            ":snake: Installing the hybrid solver...",
+            "failed installing the solver :sob:",
+            ":snake: Done."
+        )
+    else:
+        con.log(":snake: Everything already installed and working. Skipped.")
+
+    cleanup()
+
+    con.log("[green]Everything is A-OK. "
+            "You can start using MICOM now :thumbs_up:[/green]")


### PR DESCRIPTION
This adds a small install script similar to Qiime2 to set up MICOM with the hybrid solver. That way you only need a single notebook cell with:

```
% setup_micom
```

This also checks for an already working install, so it avoids breaking your installation when re-running it.